### PR TITLE
Added noscatter option to size_picker

### DIFF
--- a/dsii_dwarfs/size_picker.py
+++ b/dsii_dwarfs/size_picker.py
@@ -7,12 +7,17 @@ class SizePicker:
     linear relation of logRe vs logM* to that and measured the scatter. We use a t distribution
     with 5 degrees of freedom for the scatter to give it more outliers than a Gaussian.
     """
-    def __init__(self):
+    def __init__(self,noscatter=False):
         self.c0 = 1.74038461
         self.c1 = 0.13943115
         self.sigma = 0.17
+        self.noscatter = noscatter
         self.scatter = stats.t(loc=0,scale=self.sigma,df=5)
 
     def size(self, log_mass):
         """ Given a mass, return a random draw from the size-mass relation """
-        return self.c1*log_mass+self.c0 + self.scatter.rvs(len(log_mass))
+        if self.noscatter:
+            rekpc = self.c1*log_mass+self.c0
+        else:
+            rekpc = self.c1*log_mass+self.c0 + self.scatter.rvs(len(log_mass))
+        return rekpc


### PR DESCRIPTION
This version is used for making a grid of galaxies with no scatter on the parameters.